### PR TITLE
Update mnist_loader.py

### DIFF
--- a/src/mnist_loader.py
+++ b/src/mnist_loader.py
@@ -10,7 +10,7 @@ function usually called by our neural network code.
 
 #### Libraries
 # Standard library
-import cPickle
+import _pickle as cPickle
 import gzip
 
 # Third-party libraries


### PR DESCRIPTION
I am working on your online book and projects using Python 3.5. Since I used a different and newer python version, I came across several problems and solved them by making some changes in network.py and mnist_loader files.  Now the code is compatible with Python 3.5
I added just "import _pickle as cPickle" line because in 3.5 cPickle isn't defined and it should be used in standard library version.